### PR TITLE
STRIPES-573 prep for moving docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,45 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 ## Introduction
 
-Stripes is a toolkit for building single-page web applications that FOLIO UI modules can run in.
+Stripes is a toolkit for building single-page web applications that FOLIO UI modules can run in.  In addition being the home of Stripes [framework](doc/stripes-framework.md), this repository serves as a hub for shared Stripes documentation.
 
-Please refer to the following documents for more information:
+## Background
 
-* [Stripes CLI user guide](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md) for getting started with setting up your development environment
-* [Stripes-core documentation](https://github.com/folio-org/stripes-core#documentation-roadmap) for details on Stripes features and architecture
-* [Stripes-components](https://github.com/folio-org/stripes-components#introduction) for information on the Stripes UI component library
-* [Stripes framework](doc/stripes-framework.md) for a brief overview of stripes framework
+* [Stripes framework](doc/stripes-framework.md) - A brief overview of the Stripes framework package
+* [Overview of Stripes](https://github.com/folio-org/stripes-core/blob/master/doc/overview.md) - Concepts that guided the design of Stripes
+* [Stripes entities](https://github.com/folio-org/stripes-core/blob/master/doc/modules-apps-etc.md) - Terminology of things pertaining to Stripes
+
+
+## Developing with Stripes
+
+Getting started and new environment setup
+
+* [Quick start guide](https://github.com/folio-org/stripes-core/blob/master/doc/quick-start.md)
+* [New development setup guide](https://github.com/folio-org/stripes-core/blob/master/doc/new-development-setup.md) - More detailed overview
+* [Hello World](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#app-development) - Use Stripes CLI to create a hello world app for FOLIO
+
+Guides for development and testing
+
+* [Stripes module developer's guide](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md)
+* [Stripes CLI user guide](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md)
+* [Migrate to Stripes framework](doc/stripes-framework.md#migrating) - How to migrate an existing app to Stripes framework v1.0 
+* [Stripes-core](https://github.com/folio-org/stripes-core/blob/master/README.md)  - Details on Stripes core features including permissions and settings
+* [Stripes-components](https://github.com/folio-org/stripes-components/blob/master/README.md) - The UI component library for Stripes
+* Unit test guide - Test Stripes apps with BigTest (placeholder)
+* Integration test guide - Integration tests with Nightmare (placeholder) _Note: The [old documentation](https://github.com/folio-org/ui-testing/blob/master/README.md) is still mostly relevant, but tests are now invoked by the CLI_
+* [i18n best practices](https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md) - Overview and examples
+* [Release procedure](https://github.com/folio-org/stripes-core/blob/master/doc/release-procedure.md) - For all front-end `ui-*` and `stripes-*` modules
+* [Depending on unreleased features](doc/depending-on-unreleased-features.md)
+* [Troubleshooting guide](https://github.com/folio-org/stripes-core/blob/master/doc/troubleshooting.md) - An evolving troubleshooting guide
+
+## Implementing Stripes
+
+Guides for dev-ops and platform implementors
+
+* Overview of the tenant config, aka `stripes.config.js` (placeholder)
+* [Branding guide](https://github.com/folio-org/stripes-core/blob/master/doc/branding.md) - Apply a logo and favicon
+* [Build a platform](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#generating-a-production-build) - Use the CLI to create a production build
+
 
 ## Additional information
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 ## Introduction
 
-Stripes is a toolkit for building single-page web applications that FOLIO UI modules can run in.  In addition being the home of Stripes [framework](doc/stripes-framework.md), this repository serves as a hub for shared Stripes documentation.
+Stripes is a toolkit for building single-page web applications that FOLIO UI modules can run in.  In addition to being the home of Stripes [framework](doc/stripes-framework.md), this repository serves as a hub for shared Stripes documentation.
 
 ## Background
 


### PR DESCRIPTION
This adds links to Stripes docs in their existing locations and attempts to organize them in the process.  Doing so enables the Stripes repo to act as an entry point for front-end documentation.

Next steps:
* Move select documents from stripes-core into this repo and update readme links (separate PR)
* Update links from dev.folio.org
* Pin stripes and unpin stripes-core repos on folio-org