### PR TITLE
Add moment.utc information to internationalization doc

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -83,6 +83,16 @@ Here, the same argument `count` is formatted in two different ways; once as the 
 
 For date and time values, use `import { FormattedDate } from 'react-intl'; ... const message = <FormattedDate value={item.metadata.updatedDate} />` or `react-intl`'s methods': `this.props.intl.formatDate(loan.dueDate)` and/or `this.props.intl.formatTime(loan.dueDate)`.
 
+When comparing or manipulating dates, it is safest to operate in UTC
+mode and leave display formatting to internationalization helpers. If
+using moment, this can be done via
+[`moment.utc()`](http://momentjs.com/docs/#/parsing/utc/). This is
+because `moment()` assumes any value without timezone information to
+be in the local timezone, and converting it to UTC for displaying,
+it will be affected by the time offset. For example, `12/01`
+when given to moment and formatted to UTC for display will appear as
+`11/30` in timezones east of UTC.
+
 ### intl object
 
 The `<IntlProvider>` is at the root level of the `stripes-core` UI, so all child components can use `react-intl`'s components or `injectIntl`.


### PR DESCRIPTION
## Purpose

Tests related to dates were found to be failing for some people in other timezones. Upon investigating they were rightfully failing because UTC dates were incorrectly being formatted as local dates. This was happening because `moment()` assumes values to be local time when there is no timezone information. So dates such as `12/01` were being formatted as `11/30` when viewed in timezones east of UTC.

Related: [STCOR-265](https://issues.folio.org/browse/STCOR-265)

## Approach

Working with dates can be a nightmare. When comparing or manipulating dates, it is safest to always work in UTC and let internationalization helpers handle formatting the display for local timezones. This PR adds a short description to the dates section of the i18n doc and links to `moment.utc()`.