### PR TITLE
STRIPES-538 Add documentation for IntlConsumer

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -93,6 +93,42 @@ it will be affected by the time offset. For example, `12/01`
 when given to moment and formatted to UTC for display will appear as
 `11/30` in timezones east of UTC.
 
+### FormattedMessage  component (renderProps usage)
+
+`<FormatMessage>` defaults to wrapping the translated messages in a `<span>` - if this is undesired, it's possible to use the component in a way that only provides the string without any elemental wrapper. E.g.
+
+```
+<FormattedMessage id="module.message.id">
+  { label => (
+   <TextField 
+     label={label}
+     ...
+   />
+  )}
+</FormattedMessage>
+```
+
+### IntlConsumer component
+
+For cases where multiple translated strings are necessary, `stripes-core` provides an `<IntlConsumer>` component for accessing methods found on the `intl` object from `react-intl`. This gives module developers an additional declarative way to add translations to their JSX. It allows access to the `intl.formatMessage` method without having to depend directly HOC's or importing the `intlShape` propType.
+
+```
+import { IntlConsumer } from '@folio/stripes/core';
+
+//... later in JSX
+<IntlConsumer>
+  { intl => (
+    <SearchAndSort
+      columnMapping={{
+        name: intl.formatMessage({ id: 'module.mappedName' }),
+        status: intl.formatMessage({ id: 'module.mappedStatus' }),
+        ...
+      }}
+    />
+  )}
+</IntlConsumer>
+```
+
 ### intl object
 
 The `<IntlProvider>` is at the root level of the `stripes-core` UI, so all child components can use `react-intl`'s components or `injectIntl`.


### PR DESCRIPTION
More helpful guidance for declarative localization - 
I've updated documentation with two items: 

- The often overlooked 'renderProps' usage of `<FormattedMessage>`
- The new approach to accessing the `intl` object via the `<IntlConsumer>` component