### PR TITLE
STRIPES-631 don't export non-existent default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes
 
+## 2.7.0 (IN PROGRESS)
+
+* Don't export `default` from repos that don't include it. Fixes STRIPES-631.
+
 ## [2.6.1](https://github.com/folio-org/stripes/tree/v2.6.1) (2019-05-13)
 
 * `stripes-core` `3.5.1` https://github.com/folio-org/stripes-core/releases/tag/v3.5.1

--- a/core/index.js
+++ b/core/index.js
@@ -1,2 +1,1 @@
-export { default } from '@folio/stripes-core';
 export * from '@folio/stripes-core';

--- a/util/index.js
+++ b/util/index.js
@@ -1,2 +1,1 @@
-export { default } from '@folio/stripes-util';
 export * from '@folio/stripes-util';


### PR DESCRIPTION
Do not attempt to export `default` from modules that don't include a
default export because, duh, you cannot do that, and you get ugly
warnings like
```
WARNING in ../node_modules/@folio/stripes/core/index.js 1:0-46
"export 'default' was not found in '@folio/stripes-core'

WARNING in ../node_modules/@folio/stripes/util/index.js 1:0-46
"export 'default' was not found in '@folio/stripes-util'
```
during the build process that users report to you, and then you feel
bad for not having noticed that yourself, and then you look outside and
they sky is gray it will probably rain again because that's just how
it's been this time of year, cold and wet when there should be flowers
but there are no flowers, just cold and wet and spring without flowers
is like winter without Christmas, always winter but never Christmas, but
there's not even a magic talking animal or an evil witch to give me
candy to make me feel better and forget that it's raining error messages
on all my friends whenever they try to build stripes and all just
because I tried to export something that wasn't even there.

Fixes [STRIPES-631](https://issues.folio.org/browse/STRIPES-631)