### PR TITLE
STCOR-189 better i18n doc WRT context

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -32,20 +32,27 @@ Translators can adjust the string values in `en_US.json` and `en_GB.json` as nee
 
 ## TL;DR
 
-`stripes-core` sets up a `react-intl` `<IntlProvider>`.
+`stripes-core` sets up a `react-intl` `<IntlProvider>` available by consuming its `<IntlConsumer>` context.
 
 FOLIO front-end modules should stick to exchanging date and time information with the back end in UTC.
 
-To print a string, use
+To format a string as a `React.Node` element, use
 ```
 import { FormattedMessage } from 'react-intl';
 ...
 const message = <FormattedMessage id="the.message.id" values={{ value: "Flying Squirrel" }} />;
 ```
-When you need a plain string without a component, inject the `intl` prop into your component with [`injectIntl`](https://github.com/yahoo/react-intl/wiki/API#injection-api), then:
+If you need an actual string rather than a React.Node, as for an `aria-label` attribute, use `stripes-core`'s `<IntlConsumer>`:
 ```
-this.props.intl.formatMessage({ id: 'the.message.id' }, { value: "Moose" })
+import { IntlConsumer } from 'stripes-core';
+...
+<IntlConsumer>
+  {intl => (
+    <SomeComponent ariaLabel={intl.formatMessage({ id: 'the.message.id' })} />
+  )}
+</IntlConsumer>
 ```
+This provides the same facility as using [`injectIntl`](https://github.com/yahoo/react-intl/wiki/API#injection-api) to provide `props.intl` to your component but without using React's deprecated context mechanism.
 
 For HTML template strings, e.g. `The value <strong>{value}</strong> was removed.`, use
 ```
@@ -54,13 +61,13 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 const message = <SafeHTMLMessage id="the.message.id" values={{ value: "Frostbite Falls" }} />;
 ```
 
-For date and time values, use
+For date and time values formatted as `React.Node` elements, use
 ```
 import { FormattedDate } from 'react-intl';
 ...
 const message = <FormattedDate value={item.metadata.updatedDate} />
 ```
-or, if you need a plain string, `injectIntl` and: `this.props.intl.formatDate(loan.dueDate)` and/or `this.props.intl.formatTime(loan.dueDate)`.
+or, if you need an actual string, consume `<IntlConsumer>` as above, then: `intl.formatDate(loan.dueDate)` and/or `intl.formatTime(loan.dueDate)`.
 
 
 ## Details
@@ -103,7 +110,7 @@ when given to moment and formatted to UTC for display will appear as
 ```
 <FormattedMessage id="module.message.id">
   { label => (
-   <TextField 
+   <TextField
      label={label}
      ...
    />


### PR DESCRIPTION
Previous documentation recommended `injectIntl` which uses React's
deprecated context API and is, in fact, no longer recommended. Added
examples of using `stripes-core`'s `<IntlConsumer>` to access `intl`
instead.

Refs [STCOR-189](https://issues.folio.org/browse/STCOR-189)