### PR TITLE
bump stripes deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change history for stripes
 
+## 2.8.0 (IN PROGRESS)
+
+* `stripes-components` `5.5.0`
+* `stripes-connect` `5.3.0`
+* `stripes-core` `3.7.0`
+* `stripes-form` `2.7.0`
+* `stripes-smart-components` `2.8.0`
+* `stripes-util` `1.5.0`
+
 ## [2.7.4](https://github.com/folio-org/stripes/tree/v2.7.4) (2019-06-12)
 
 * `stripes-components` `5.4.2` https://github.com/folio-org/stripes-components/releases/tag/v5.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -16,13 +16,13 @@
     "lint": "eslint ./"
   },
   "dependencies": {
-    "@folio/stripes-components": "~5.4.2",
-    "@folio/stripes-connect": "~5.2.1",
-    "@folio/stripes-core": "~3.6.0",
-    "@folio/stripes-form": "~2.6.0",
+    "@folio/stripes-components": "~5.5.0",
+    "@folio/stripes-connect": "~5.3.0",
+    "@folio/stripes-core": "~3.7.0",
+    "@folio/stripes-form": "~2.7.0",
     "@folio/stripes-logger": "~1.0.0",
-    "@folio/stripes-smart-components": "~2.7.2",
-    "@folio/stripes-util": "~1.4.0",
+    "@folio/stripes-smart-components": "~2.8.0",
+    "@folio/stripes-util": "~1.5.0",
     "react": "~16.8.6",
     "react-dom": "~16.8.6",
     "react-redux": "~5.1.1",


### PR DESCRIPTION
New features in stripes dependencies mean we need to bump the minor
versions of everything in the stripes dependency chain.