### PR TITLE
STCOM-581 move react et al to peerDeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes
 
+## 2.12.0 (IN PROGRESS)
+
+* Accept react, react-dom, react-redux, and redux as peerDependencies. (Refs STCOM-581)
+
 ## [2.11.1](https://github.com/folio-org/stripes/tree/v2.11.1) (2019-09-27)
 
 * `stripes-core` `3.10.1` https://github.com/folio-org/stripes-core/releases/tag/v3.10.1

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@folio/stripes-final-form": "~1.4.0",
     "@folio/stripes-logger": "~1.0.0",
     "@folio/stripes-smart-components": "~2.12.0",
-    "@folio/stripes-util": "~1.5.0",
-    "react": "~16.8.6",
-    "react-dom": "~16.8.6",
+    "@folio/stripes-util": "~1.5.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*",
     "react-redux": "~5.1.1",
     "redux": "~3.7.2"
   },


### PR DESCRIPTION
Only the platform should provide libraries that are passed across module
boundaries. Otherwise, there is the risk that multiple incompatible
versions of these apps will be installed locally within each module,
rather than hoisted to the top level and shared.

Refs [STCOM-581](https://issues.folio.org/browse/STCOM-581)