### PR TITLE
Release v2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes
 
+## [2.11.2](https://github.com/folio-org/stripes/tree/v2.11.2) (2019-10-08)
+
+* No changes since 2.11.1, but we need a new `latest` to trick yarn; see STCOR-393.
+
 ## [2.11.1](https://github.com/folio-org/stripes/tree/v2.11.1) (2019-09-27)
 
 * `stripes-core` `3.10.1` https://github.com/folio-org/stripes-core/releases/tag/v3.10.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {


### PR DESCRIPTION
This is no different than v2.11.1 aside from an updated version number in the `package.json`, but since `yarn install` will first attempt to satisfy a dependency with the version labeled by the `dist-tag` `latest`, and _then_ satisfy additional (possibly more strict) dependencies by adding additional copies to the bundle, sometimes we get multiple copies of things we don't want multiple copies of. 

Wha? If you have dev deps on stripes and stripes-cli, which both have a dep on stripes-core, it's easy to get multiple copies of stripes-core in the bundle because those can conflict because we'll get a newish stripes-core from stripes-cli and an oldish one from that backported `latest` release. 