### PR TITLE
Updated eslint and eslint-config-stripes versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "redux": "~3.7.2"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^3.2.1",
-    "eslint": "^5.0.0"
+    "@folio/eslint-config-stripes": "^5.0.0",
+    "eslint": "^6.2.1"
   }
 }


### PR DESCRIPTION
- Fulfills part of https://issues.folio.org/browse/STRIPES-648.
- Updated eslint-config-stripes to 5.0.0 which also contains updated version of eslint.