### PR TITLE
merge 4.1.5 release-branch back into b4.1 for continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes
 
+## [4.1.5](https://github.com/folio-org/stripes/tree/v4.1.5) (2020-09-29)
+
+* `stripes-core` `5.0.3` https://github.com/folio-org/stripes-core/releases/tag/v5.0.3
+
 ## [4.1.4](https://github.com/folio-org/stripes/tree/v4.1.4) (2020-07-10)
 
 * `stripes-smart-components` `4.1.5` https://github.com/folio-org/stripes-smart-components/releases/tag/v4.1.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -18,7 +18,7 @@
   "dependencies": {
     "@folio/stripes-components": "~7.0.4",
     "@folio/stripes-connect": "~5.6.1",
-    "@folio/stripes-core": "~5.0.1",
+    "@folio/stripes-core": "~5.0.3",
     "@folio/stripes-form": "~4.0.1",
     "@folio/stripes-final-form": "~3.0.0",
     "@folio/stripes-logger": "~1.0.0",


### PR DESCRIPTION
Release `v4.1.5` was tagged on a branch split from the `v4.1.4` tag on the `b4.1` branch rather than directly on `b4.1` itself (whoops, but NBD). This PR merges that release branch back into `b4.1` in order to provide continuity with future `v4.1.x` patch releases tagged directly on the `b4.1` branch.