### PR TITLE
STRIPES-721 increment redux-related dependencies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 ## v6.0.0; Iris (API freeze 2021-01-15; release 2021-02-19)
 
 * [STCOM-791](https://issues.folio.org/browse/STCOM-791) Remove deprecated Dropdown logic and Tether logic paths
+* [STRIPES-721](https://issues.folio.org/browse/STRIPES-721) increment to react-redux v7, redux-form v8, redux v4
 
 ## Juniper (API freeze 2021)
 


### PR DESCRIPTION
Increment to `react-redux` `v7`, `redux-form` `v8`, `redux` `v4`. We are
a major version behind in each of these, and the longer we wait the more
difficult it will be to update. It is particularly worth noting that the
`react-redux` `v7` release restores the APIs that were removed in `v6`,
and which had previously made this look like a substantial task. In
truth, it turned out to be nearly painless, as @doytch discovered when
he finally, ahem, actually tried this out while I was busy wringing my
hands about what a difficult path it would be to tread.

Incrementing `redux-form` to `v8` will also substantially reduce the
console noise we see in development (see [STCOR-353](https://issues.folio.org/browse/STCOR-353)).

Refs [STRIPES-721](https://issues.folio.org/browse/STRIPES-721)