### PR TITLE
STRIPES-722 increment react to v17

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 ## v6.0.0; Iris (API freeze 2021-01-15; release 2021-02-19)
 
 * [STCOM-791](https://issues.folio.org/browse/STCOM-791) Remove deprecated Dropdown logic and Tether logic paths
+* [STRIPES-722](https://issues.folio.org/browse/STRIPES-722) increment to react v17
 
 ## Juniper (API freeze 2021)
 


### PR DESCRIPTION
`react` `v17` isn't actually a breaking change, but it paves the way to
simplify the adoption of breaking changes in `v18`. Hence, we should
adopt this as soon as possible in order to simplify the process of
future upgrades.

Refs [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)