### PR TITLE
UXPROD-2266 refactor from redux-form to final-form

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,4 +12,6 @@
 
 ## Juniper (API freeze 2021)
 
+* [UXPROD-2266](https://issues.folio.org/browse/UXPROD-2266) Refactor from redux-form to final-form
+
 ##


### PR DESCRIPTION
While most apps have already completed this transition, ui-users,
ui-requests, and, substantially, stripes-smart-components (including
custom fields) still rely on redux-form.

redux-form is effectively, if not officially, deprecated and has been
for some time now. We would be well served by eliminating it, and the
outdated dependencies it brings along.

While it may be possible to provide the shared components from
`stripes-smart-components` in a compatible way, the least amount of
effort is to simply make the switch in a breaking release and never look
back. Yep, it's harsh, but it's never going to be easier than it is
right now when we have relatively few apps to migrate.

Refs [UXPROD-2266](https://issues.folio.org/browse/UXPROD-2266)