### PR TITLE
Add @babel/eslint-parser upgrade to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,4 +12,6 @@
 
 ## Juniper (API freeze 2021)
 
+* Switch to [`@babel/eslint-parser`](https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint) instead of `babel-eslint`
+
 ##


### PR DESCRIPTION
We're currently using `babel-eslint` which is old and doesn't work properly. It throws false positives for things like `for (const foo of bar)` loops in v8, and v10 has parsing bugs in our env. [Meanwhile, `@babel/eslint-parser` is out and is the replacement for babel-eslint.](https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint)

We're seeing a bunch of cases where legitimate eslint errors are getting merged into code because the list of eslint errors is so large that it's being ignored in PRs. This needs to get done to clean up a bunch of the false positives so that we can attack the stuff that's currently just being ignored by everyone like linter errors related to React hooks.