### PR TITLE
STRIPES-723 add RXJS upgrade to Juniper roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,13 +3,15 @@
 ## v5.0.0; Honeysuckle (API freeze 2020-09-18; release 2020-10-06)
 
 * [STCOM-492](https://issues.folio.org/browse/STCOM-492) Change filter search cql syntax to use == not =
-* [STRIPES-674](https://issues.folio.org/browse/STRIPES-672)Increment `react-router` to `v5.2`
-* [STRIPES-694](https://issues.folio.org/browse/STRIPES-694)Increment `react-intl` to `v5.7`
+* [STRIPES-674](https://issues.folio.org/browse/STRIPES-672) Increment `react-router` to `v5.2`
+* [STRIPES-694](https://issues.folio.org/browse/STRIPES-694) Increment `react-intl` to `v5.7`
 
 ## v6.0.0; Iris (API freeze 2021-01-15; release 2021-02-19)
 
 * [STCOM-791](https://issues.folio.org/browse/STCOM-791) Remove deprecated Dropdown logic and Tether logic paths
 
 ## Juniper (API freeze 2021)
+
+* [STRIPES-723](https://issues.folio.org/browse/STRIPES-723) Upgrade RxJS to v6
 
 ##


### PR DESCRIPTION
Increment `rxjs` from `v5` to `v6`. This will require changes at least
in `stripes-core` and `stripes-connect` and probably other apps as well
(`ui-eholdings`).

If the version needs to be synced across all modules, the dependency
should be moved up to the platform level. If it only needs to be synced
across the stripes libraries, i.e. if apps' use is internal, I _think_
we would be fine supplying it to stripes-* via `@folio/stripes` but
we'll need to test that.

In either case, if we are changing a peer dependency, this work will
need to be part of a major release. Do we want to aim at Juniper here,
or should we push this out further? 

Refs [STRIPES-723](https://issues.folio.org/browse/STRIPES-723)