### PR TITLE
Add NPM7 migration to roadmap for Kiwi

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,4 +17,6 @@
 * [STRIPES-723](https://issues.folio.org/browse/STRIPES-723) Upgrade RxJS to v6
 * Switch to [`@babel/eslint-parser`](https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint) instead of `babel-eslint`
 
-##
+## Kiwi
+
+* [STRIPES-676](https://issues.folio.org/browse/STRIPES-676) move to NPM 7 (from Yarn 1.0)


### PR DESCRIPTION
**Q: Huh? What's the point of this PR???**
A: This PR updates the `ROADMAP.md` file that we use to maintain an at-a-glance plan for Stripes development in the future. It doesn't _commit_ to the work, but it does represent the goal of Stripes' authors. This is the first of a series of "you've been warned" steps when planning breaking changes.

**Onto the specifics of this PR...**
Moving to NPM 7 would mean that building a Stripes bundle uses NPM 7 (and Node 15/16) instead of using `yarn`. This has implications on front-end devs and dev-ops.

The wins it gives us include:
- removing an entire category of difficult-to-debug errors that crop up when multiple versions of a library are imported because Yarn is bad at resolving compatible versions
- better error reporting
- not needing to define your peer dependencies in your dev dependencies