### PR TITLE
reference yarn v1 specifically

### DIFF
--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -10,7 +10,7 @@
 ## Prerequisites
 
 * [Node.js](https://nodejs.org/) with an [active LTS version](https://github.com/nodejs/Release#release-schedule)
-* [Yarn](https://yarnpkg.com/) package manager
+* [Yarn v1](https://classic.yarnpkg.com/lang/en/) package manager
 * [Vagrant](https://www.vagrantup.com/downloads.html) for optionally hosting a local [pre-built back-end](https://github.com/folio-org/folio-ansible/blob/master/doc/index.md) environment
 
 Inform Yarn that packages in the `@folio` scope are found on the FOLIO NPM repository:


### PR DESCRIPTION
We rely on yarn v1; this documentation predates v2 or v3 and thus was not specific in the links it provided.