### PR TITLE
STRIPES-818: Re-export TypeScript definitions from stripes-components

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@folio/stripes-components';


### PR DESCRIPTION
In tandem with https://github.com/folio-org/stripes-components/pull/1824, this PR re-exports any types that `stripes-components` provides.