### PR TITLE
Release v7.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change history for stripes
 
+## [7.3.1](https://github.com/folio-org/stripes/tree/v7.3.1) (2022-10-13)
+
+* _Actually update_ the minor versions of these packages:
+  * `stripes-components` `10.3.0` https://github.com/folio-org/stripes-components/releases/tag/v10.3.0
+  * `stripes-core` `8.3.0` https://github.com/folio-org/stripes-core/releases/tag/v8.3.0
+  * `stripes-form` `7.1.1` https://github.com/folio-org/stripes-form/releases/tag/v7.1.1
+  * `stripes-final-form` `6.1.1` https://github.com/folio-org/stripes-final-form/releases/tag/v6.1.1
+  * `stripes-smart-components` `7.3.0` https://github.com/folio-org/stripes-smart-components/releases/tag/v7.3.0
+
 ## [7.3.0](https://github.com/folio-org/stripes/tree/v7.3.0) (2022-10-13)
 
 * `stripes-components` `10.3.0` https://github.com/folio-org/stripes-components/releases/tag/v10.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -17,13 +17,13 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@folio/stripes-components": "~10.2.0",
+    "@folio/stripes-components": "~10.3.0",
     "@folio/stripes-connect": "~7.1.0",
-    "@folio/stripes-core": "~8.2.0",
-    "@folio/stripes-final-form": "~6.1.0",
-    "@folio/stripes-form": "~7.1.0",
+    "@folio/stripes-core": "~8.3.0",
+    "@folio/stripes-final-form": "~6.1.1",
+    "@folio/stripes-form": "~7.1.1",
     "@folio/stripes-logger": "~1.0.0",
-    "@folio/stripes-smart-components": "~7.2.0",
+    "@folio/stripes-smart-components": "~7.3.0",
     "@folio/stripes-util": "~5.2.0",
     "react-redux": "~7.2.0",
     "redux": "~4.0.0"


### PR DESCRIPTION
_Actually update_ the minor versions of the constituent stripes-* packages. The [7.3.0 release](https://github.com/folio-org/stripes/releases/tag/v7.3.0) left them at their 7.2.0 versions 😬 , despite what the changelog claimed.