### PR TITLE
STRIPES-820: Add stripes-ui as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@folio/stripes-form": "~7.1.1",
     "@folio/stripes-logger": "~1.0.0",
     "@folio/stripes-smart-components": "~7.4.0",
+    "@folio/stripes-ui": "~1.0.0",
     "@folio/stripes-util": "~5.2.0",
     "react-redux": "~7.2.0",
     "redux": "~4.0.0"

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,0 +1,1 @@
+export * from '@folio/stripes-ui';


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-820

Add `stripes-ui` as a dependency.

The other PRs related to this are:

https://github.com/folio-org/stripes-core/pull/1256
https://github.com/folio-org/stripes-webpack/pull/80
