### PR TITLE
bump major version to 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change history for stripes
 
-## 7.4.0 (IN PROGRESS)
+## 8.0.0 (IN PROGRESS)
+
+* `stripes-components` `11.0.0` https://github.com/folio-org/stripes-components/releases/tag/v11.0.0
+* `stripes-core` `9.0.0` https://github.com/folio-org/stripes-core/releases/tag/v9.0.0
+* `stripes-form` `8.0.0` https://github.com/folio-org/stripes-form/releases/tag/v8.0.0
+* `stripes-final-form` `7.0.0` https://github.com/folio-org/stripes-final-form/releases/tag/v7.0.0
+* `stripes-smart-components` `8.0.0` https://github.com/folio-org/stripes-smart-components/releases/tag/v8.0.0
 
 ## [7.3.1](https://github.com/folio-org/stripes/tree/v7.3.1) (2022-10-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -17,13 +17,13 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@folio/stripes-components": "~10.4.0",
+    "@folio/stripes-components": "~11.0.0",
     "@folio/stripes-connect": "~7.1.0",
-    "@folio/stripes-core": "~8.4.0",
-    "@folio/stripes-final-form": "~6.1.1",
-    "@folio/stripes-form": "~7.1.1",
+    "@folio/stripes-core": "~9.0.0",
+    "@folio/stripes-final-form": "~7.0.0",
+    "@folio/stripes-form": "~8.0.0",
     "@folio/stripes-logger": "~1.0.0",
-    "@folio/stripes-smart-components": "~7.4.0",
+    "@folio/stripes-smart-components": "~8.0.0",
     "@folio/stripes-ui": "~1.0.0",
     "@folio/stripes-util": "~5.2.0",
     "react-redux": "~7.2.0",
@@ -38,3 +38,4 @@
     "react-dom": "^17.0.2"
   }
 }
+


### PR DESCRIPTION
Bump the major version to 8.0.0 to reflect incoming breaking changes in stripes-components, stripes-core, and possibly stripes-smart-components.