### PR TITLE
[STRIPES-859] Re-export type declarations from stripes-types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,12 @@
 {
-  "extends": "@folio/eslint-config-stripes"
+  "extends": "@folio/eslint-config-stripes",
+  "overrides": [
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        // eslint does not like .d.ts files without a corresponding .js file
+        "import/no-unresolved": "off"
+      }
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * *BREAKING* `stripes-smart-components` `9.0`
 * *BREAKING* `stripes-ui` `2.0.0`
 * *BREAKING* `react` `v18`
+* `stripes-types` `v1`
 
 ## [8.0.0](https://github.com/folio-org/stripes/tree/v8.0.0) (2023-01-31)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Stripes is a toolkit for building single-page web applications that FOLIO UI mod
 * [Overview of Stripes](doc/overview.md) - Concepts that guided the design of Stripes
 * [Stripes entities](doc/modules-apps-etc.md) - Terminology of things pertaining to Stripes
 
-
 ## Developing with Stripes
 
 Getting started and new environment setup
@@ -38,6 +37,10 @@ Guides for development and testing
 * [Release procedure](doc/release-procedure.md) - For all front-end `ui-*` and `stripes-*` modules
 * [Depending on unreleased features](doc/depending-on-unreleased-features.md)
 * [Troubleshooting guide](doc/troubleshooting.md) - An evolving troubleshooting guide
+
+## TypeScript support
+
+Typings for the Stripes framework may be found in [stripes-types](https://github.com/folio-org/stripes-types)
 
 ## Implementing Stripes
 

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@folio/stripes-types/components';

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@folio/stripes-types/core';

--- a/final-form/index.d.ts
+++ b/final-form/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@folio/stripes-types/final-form';
+export * from '@folio/stripes-types/final-form';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@folio/stripes-form": "~9.0.0",
     "@folio/stripes-logger": "~1.0.0",
     "@folio/stripes-smart-components": "~9.0.0",
-    "@folio/stripes-types": "^1.0.1",
+    "@folio/stripes-types": "^2.0.0",
     "@folio/stripes-ui": "~2.0.0",
     "@folio/stripes-util": "~6.0.0",
     "redux": "^4.2.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@folio/stripes-form": "~8.1.0",
     "@folio/stripes-logger": "~1.0.0",
     "@folio/stripes-smart-components": "~8.1.0",
+    "@folio/stripes-types": "^1.0.1",
     "@folio/stripes-ui": "~1.1.0",
     "@folio/stripes-util": "~5.2.1",
     "redux": "~4.0.0"
@@ -34,6 +35,7 @@
     "react-redux": "~8.0.5"
   },
   "peerDependencies": {
+    "@types/react": "^17.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "~8.0.5"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-redux": "~8.0.5"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "~8.0.5"

--- a/smart-components/index.d.ts
+++ b/smart-components/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '@folio/stripes-types/smart-components';
+export * from '@folio/stripes-types/smart-components';


### PR DESCRIPTION
# [Jira STRIPES-859](https://issues.folio.org/browse/STRIPES-859)

This PR adds `index.d.ts` files to re-export types stored in `stripes-types`.  Initially, this consists of typings for `stripes-components`, `stripes-core`, `stripes-final-form`, and `stripes-smart-components` — all other modules will have no associated type information, as it was previously.

For convenience, here is a link to [stripes-types](https://github.com/folio-org/stripes-types/tree/v1.0.1).

### What is in `stripes-types` so far?

For modules `stripes-components`, `stripes-core`, and `stripes-smart-components`, all declarations are denoted as `any`, disabling type checking and having no effect, e.g.:

```ts
export const RootContext: any;
export const withRoot: any;
export const CalloutContext: any;
export const useCallout: any;
export const stripesShape: any;
export const withStripes: any;
export const useStripes: any;
...
```

All exports from the original modules' `index.js` files are included here.

`stripes-final-form` is the exception to this; since it only has one export, we have created actual type definitions for the [stripesFinalForm function](https://github.com/folio-org/stripes-types/blob/v1.0.1/final-form/lib/stripesFinalForm.d.ts).

### What effect will this PR have?

First off, **this will only affect TypeScript modules**.  Modules which do not use TS will not use the TS compiler and thus these type declaration files are irrelevant.

There are (as far as I know) only two modules which use TypeScript: `ui-calendar` and `ui-bulk-edit`, both of which contain their own type declarations for these modules ([calendar](https://github.com/folio-org/ui-calendar/blob/master/src/typings.d.ts), [bulk-edit](https://github.com/folio-org/ui-bulk-edit/tree/master/src/typings/stripes)) _which take precedence over any we specify here_.  Therefore, we can safely develop these types without breaking any builds; these will only be relied upon downstream once the overridden definitions are removed (which will happen after this PR is merged and additional type development).

@zburke @JohnC-80 if you would please review this when you're able!  