### PR TITLE
STRIPES-860: Bump redux to ^4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `stripes-core` `9.1.0` https://github.com/folio-org/stripes-core/releases/tag/v9.1.0
 * `stripes-smart-components` `8.1.0` https://github.com/folio-org/stripes-smart-components/releases/tag/v8.1.0
 * `stripes-ui` `1.1.0` https://github.com/folio-org/stripes-ui/releases/tag/v1.1.0
+* Increment `redux` to `~4.2`. Refs STRIPES-860.
 
 ## [8.0.0](https://github.com/folio-org/stripes/tree/v8.0.0) (2023-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * `stripes-core` `9.1.0` https://github.com/folio-org/stripes-core/releases/tag/v9.1.0
 * `stripes-smart-components` `8.1.0` https://github.com/folio-org/stripes-smart-components/releases/tag/v8.1.0
 * `stripes-ui` `1.1.0` https://github.com/folio-org/stripes-ui/releases/tag/v1.1.0
-* Increment `redux` to `~4.2`. Refs STRIPES-860.
+* Loosen `redux` dependency to `^4.2.1`, aligning it across repos. Refs STRIPES-860.
 
 ## [8.0.0](https://github.com/folio-org/stripes/tree/v8.0.0) (2023-01-31)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@folio/stripes-smart-components": "~8.1.0",
     "@folio/stripes-ui": "~1.1.0",
     "@folio/stripes-util": "~5.2.1",
-    "redux": "~4.2.1"
+    "redux": "^4.2.1"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@folio/stripes-smart-components": "~8.1.0",
     "@folio/stripes-ui": "~1.1.0",
     "@folio/stripes-util": "~5.2.1",
-    "redux": "~4.0.0"
+    "redux": "~4.2.1"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^6.1.0",


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-860

Bump redux to ^4.2.1 to align with what will be installed on the platform: https://github.com/folio-org/platform-complete/pull/2407

