### PR TITLE
STRIPES-872 BREAKING react 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 9.0.0 IN PROGRESS
 
-* `stripes-components` `11.1.0` https://github.com/folio-org/stripes-components/releases/tag/v11.1.0
-* `stripes-core` `9.1.0` https://github.com/folio-org/stripes-core/releases/tag/v9.1.0
-* `stripes-smart-components` `8.1.0` https://github.com/folio-org/stripes-smart-components/releases/tag/v8.1.0
-* `stripes-ui` `1.1.0` https://github.com/folio-org/stripes-ui/releases/tag/v1.1.0
-* Loosen `redux` dependency to `^4.2.1`, aligning it across repos. Refs STRIPES-860.
+* *BREAKING* `stripes-components` `12.0.0`
+* *BREAKING* `stripes-connect` `9.0.0`
+* *BREAKING* `stripes-core` `10.0.0`
+* *BREAKING* `stripes-util` `6.0.0`
+* *BREAKING* `stripes-form` `9.0.0`
+* *BREAKING* `stripes-final-form` `8.0.0`
+* *BREAKING* `stripes-smart-components` `9.0`
+* *BREAKING* `stripes-ui` `2.0.0`
+* *BREAKING* `react` `v18`
 
 ## [8.0.0](https://github.com/folio-org/stripes/tree/v8.0.0) (2023-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 9.0.0 IN PROGRESS
 
+* Loosen `redux` dependency to `^4.2.1`, aligning it across repos. Refs STRIPES-860.
 * *BREAKING* `stripes-components` `12.0.0`
 * *BREAKING* `stripes-connect` `9.0.0`
 * *BREAKING* `stripes-core` `10.0.0`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "redux": "^4.2.1"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0-.0",
+    "@folio/eslint-config-stripes": "^7.0.0",
     "eslint": "^7.32.0",
     "react-redux": "~8.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -17,25 +17,25 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@folio/stripes-components": "~11.1.0",
-    "@folio/stripes-connect": "~8.2.0",
-    "@folio/stripes-core": "~9.1.0",
-    "@folio/stripes-final-form": "~7.1.0",
-    "@folio/stripes-form": "~8.1.0",
+    "@folio/stripes-components": "~12.0.0",
+    "@folio/stripes-connect": "~9.0.0",
+    "@folio/stripes-core": "~10.0.0",
+    "@folio/stripes-final-form": "~8.0.0",
+    "@folio/stripes-form": "~9.0.0",
     "@folio/stripes-logger": "~1.0.0",
-    "@folio/stripes-smart-components": "~8.1.0",
-    "@folio/stripes-ui": "~1.1.0",
-    "@folio/stripes-util": "~5.2.1",
+    "@folio/stripes-smart-components": "~9.0.0",
+    "@folio/stripes-ui": "~2.0.0",
+    "@folio/stripes-util": "~6.0.0",
     "redux": "^4.2.1"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^6.1.0",
+    "@folio/eslint-config-stripes": "^7.0-.0",
     "eslint": "^7.32.0",
     "react-redux": "~8.0.5"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-redux": "~8.0.5"
   }
 }


### PR DESCRIPTION
Upgrade `react` to `v18`, and all `@folio/stripes-*` dependencies accordingly.

Refs [STRIPES-872](https://issues.folio.org/browse/STRIPES-872)