### PR TITLE
STRIPES-894 loosen react-redux to mitigate install warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^7.0.0",
     "eslint": "^7.32.0",
-    "react-redux": "~8.0.5"
+    "react-redux": "^8.0.5"
   },
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "~8.0.5"
+    "react-redux": "^8.0.5"
   }
 }


### PR DESCRIPTION
Align the `react-redux` dependency constraint across `@folio/stripes` and `platform-complete`. Mismatched constraints cause build warnings in the parent package like 
```
warning " > @folio/stripes@9.1.100000303" has incorrect peer dependency "react-redux@~8.0.5".
```

Refs [STRIPES-894](https://issues.folio.org/browse/STRIPES-894)