### PR TITLE
Release v9.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes
 
+## [9.0.4](https://github.com/folio-org/stripes/tree/v9.0.5) (2024-02-28)
+
+* `stripes-components` `12.0.5` https://github.com/folio-org/stripes-components/releases/tag/v12.0.5
+
 ## [9.0.4](https://github.com/folio-org/stripes/tree/v9.0.4) (2023-12-11)
 
 * `stripes-components` `12.0.4` https://github.com/folio-org/stripes-components/releases/tag/v12.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes
 
-## [9.0.4](https://github.com/folio-org/stripes/tree/v9.0.5) (2024-02-28)
+## [9.0.5](https://github.com/folio-org/stripes/tree/v9.0.5) (2024-02-28)
 
 * `stripes-components` `12.0.5` https://github.com/folio-org/stripes-components/releases/tag/v12.0.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -17,7 +17,7 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@folio/stripes-components": "~12.0.4",
+    "@folio/stripes-components": "~12.0.5",
     "@folio/stripes-connect": "~9.0.0",
     "@folio/stripes-core": "~10.0.3",
     "@folio/stripes-final-form": "~8.0.0",


### PR DESCRIPTION
Includes [stripes-components v12.0.5](https://github.com/folio-org/stripes-components/releases/tag/v12.0.5)