### PR TITLE
Release v10.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes
 
+## [10.0.10](https://github.com/folio-org/stripes/tree/v10.0.10) (2025-05-06)
+* `stripes-components `13.0.6` https://github.com/folio-org/stripes-components/releases/tag/v13.0.6
+
 ## [10.0.9](https://github.com/folio-org/stripes/tree/v10.0.9) (2025-04-30)
 
 * `stripes-core `11.0.6` https://github.com/folio-org/stripes-core/releases/tag/v11.0.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes",
-  "version": "10.0.9",
+  "version": "10.0.10",
   "description": "Stripes framework",
   "repository": "https://github.com/folio-org/stripes",
   "publishConfig": {
@@ -17,7 +17,7 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@folio/stripes-components": "~13.0.5",
+    "@folio/stripes-components": "~13.0.6",
     "@folio/stripes-connect": "~10.0.0",
     "@folio/stripes-core": "~11.0.6",
     "@folio/stripes-final-form": "~9.0.0",


### PR DESCRIPTION
Includes `stripes-components` v13,0.6:
- Bugfix - clicking the trigger on an open <Popover> now closes the <Popover> instead of closing/reopening. Refs STCOM-1429.